### PR TITLE
Remove deprecated "version" in docker-compose.yml

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,3 @@
-version: "2.1"
-
 services:
   blocky:
     image: spx01/blocky
@@ -40,8 +38,8 @@ services:
     environment:
       - GF_PANELS_DISABLE_SANITIZE_HTML=true
       - GF_INSTALL_PLUGINS=grafana-piechart-panel
-    restart: always    
+    restart: always
 
 volumes:
-    prometheus_data: {}
-    grafana_data: {}
+  prometheus_data: {}
+  grafana_data: {}


### PR DESCRIPTION
Reference: https://docs.docker.com/reference/compose-file/version-and-name/#version-top-level-element-obsolete